### PR TITLE
Update template_config.yml

### DIFF
--- a/template_config.yml
+++ b/template_config.yml
@@ -59,10 +59,11 @@ servers:
     hostname: ''
 
     # Port of server to which logs will be sent
+    # FORMAT: (INT, No Quotes)
     # MINIMUM: 0
     # MAXIMUM: 65535
     # REQUIRED
-    port: ''
+    port: 
 
     # Transport protocol used to communicate with the server
     # OPTIONS: TCP, TCPSSL, UDP


### PR DESCRIPTION
Removed single quotes from port specification and added note.

When specifying port in single quotes within template_config.yml, the config will fail to parse.